### PR TITLE
tests: more delete tests for koji_tag_inheritance

### DIFF
--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -39,16 +39,22 @@ options:
    parent_tag:
      description:
        - The name of the Koji tag that will be the parent of the child.
-     required: true
+       - When defining an inheritance relationship with `state: present`, you
+         must specify a parent tag.
+       - When deleting an inheritance relationship with `state: absent`, you
+         may specify a parent tag name, priority, or both to decide the link to
+         remove. If both are specified, both must match.
+     required: true (add/modify), false (remove)
    priority:
      description:
        - The priority of this parent for this child. Parents with smaller
          numbers will override parents with bigger numbers.
-       - When defining an inheritance relationship with "state: present", you
-         must specify a priority. When deleting an inheritance relationship
-         with "state: absent", you should not specify a priority. Ansible will
-         simply remove the parent_tag link, regardless of its priority.
-     required: true
+       - When defining an inheritance relationship with `state: present`, you
+         must specify a priority.
+       - When deleting an inheritance relationship with `state: absent`, you
+         may specify a parent tag name, priority, or both to decide the link to
+         remove. If both are specified, both must match.
+     required: true (add/modify), false (remove)
    maxdepth:
      description:
        - By default, a tag's inheritance chain is unlimited. This means that
@@ -198,6 +204,9 @@ def add_tag_inheritance(session, child_tag, parent_tag, priority, maxdepth,
     :param bool check_mode: don't make any changes
     :return: result (dict)
     """
+    if parent_tag is None:
+        raise ValueError('parent tag name required to set tag inheritance for '
+                         'tag %s' % child_tag)
     result = {'changed': False, 'stdout_lines': []}
     data = get_ids_and_inheritance(session, child_tag, parent_tag)
     child_id, parent_id, current_inheritance = data
@@ -220,15 +229,9 @@ def add_tag_inheritance(session, child_tag, parent_tag, priority, maxdepth,
     for rule in current_inheritance:
         if rule == new_rule:
             return result
-        if rule['priority'] == priority:
-            # prefix taginfo-style inheritance strings with diff-like +/-
-            result['stdout_lines'].append('dissimilar rules:')
-            result['stdout_lines'].extend(
-                    map(lambda r: ' -' + r,
-                        common_koji.describe_inheritance_rule(rule)))
-            result['stdout_lines'].extend(
-                    map(lambda r: ' +' + r,
-                        common_koji.describe_inheritance_rule(new_rule)))
+        # If either name or priority matches, but the other value is different,
+        # we need to delete the partial match to add ours
+        if (rule['name'] == parent_tag) != (rule['priority'] == priority):
             delete_rule = rule.copy()
             # Mark this rule for deletion
             delete_rule['delete link'] = True
@@ -248,21 +251,29 @@ def add_tag_inheritance(session, child_tag, parent_tag, priority, maxdepth,
     return result
 
 
-def remove_tag_inheritance(session, child_tag, parent_tag, check_mode):
+def remove_tag_inheritance(session, child_tag, parent_tag, priority,
+                           check_mode):
     """
     Ensure that a tag inheritance rule does not exist.
 
     :param session: Koji client session
     :param str child_tag: Koji tag name
     :param str parent_tag: Koji tag name
+    :param int priority: Koji inheritance link priority
     :param bool check_mode: don't make any changes
     :return: result (dict)
     """
+    if parent_tag is None and priority is None:
+        raise ValueError('parent name or priority required to remove tag %s '
+                         'inheritance' % child_tag)
     result = {'changed': False, 'stdout_lines': []}
     current_inheritance = session.getInheritanceData(child_tag)
     found_rule = {}
     for rule in current_inheritance:
-        if rule['name'] == parent_tag:
+        # Only one of parent_tag or priority can be None, so mark the rule for
+        # deletion unless the field is specified *and* doesn't match
+        if (parent_tag is None or rule['name'] == parent_tag) \
+                and (priority is None or rule['priority'] == priority):
             found_rule = rule.copy()
             # Mark this rule for deletion
             found_rule['delete link'] = True
@@ -282,7 +293,7 @@ def run_module():
     module_args = dict(
         koji=dict(type='str', required=False),
         child_tag=dict(type='str', required=True),
-        parent_tag=dict(type='str', required=True),
+        parent_tag=dict(type='str', required=False),
         priority=dict(type='int', required=False),
         maxdepth=dict(type='int', required=False, default=None),
         pkg_filter=dict(type='str', required=False, default=''),
@@ -321,6 +332,7 @@ def run_module():
         result = remove_tag_inheritance(session,
                                         child_tag=params['child_tag'],
                                         parent_tag=params['parent_tag'],
+                                        priority=params['priority'],
                                         check_mode=check_mode)
     else:
         module.fail_json(msg="State must be 'present' or 'absent'.",

--- a/tests/integration/koji_tag_inheritance/delete-2.yml
+++ b/tests/integration/koji_tag_inheritance/delete-2.yml
@@ -1,28 +1,28 @@
-# Delete an inheritance relationship by parent_tag name.
+# Delete an inheritance relationship by priority.
 ---
 
 - koji_tag:
-    name: delete-1-parent
+    name: delete-2-parent
     state: present
 
 - koji_tag:
-    name: delete-1-child
+    name: delete-2-child
     state: present
     inheritance:
-    - parent: delete-1-parent
+    - parent: delete-2-parent
       priority: 0
 
-- name: delete an inheritance relationship by parent_tag name.
+- name: delete an inheritance relationship by priority
   koji_tag_inheritance:
-    parent_tag: delete-1-parent
-    child_tag: delete-1-child
+    child_tag: delete-2-child
+    priority: 0
     state: absent
 
 # Assert that we have no parents.
 
 - koji_call:
     name: getInheritanceData
-    args: [delete-1-child]
+    args: [delete-2-child]
   register: inheritance
 
 - assert:

--- a/tests/integration/koji_tag_inheritance/delete-3.yml
+++ b/tests/integration/koji_tag_inheritance/delete-3.yml
@@ -1,0 +1,31 @@
+# Delete an inheritance relationship by parent_tag name *and* priority.
+---
+
+- koji_tag:
+    name: delete-3-parent
+    state: present
+
+- koji_tag:
+    name: delete-3-child
+    state: present
+    inheritance:
+    - parent: delete-3-parent
+      priority: 0
+
+- name: delete an inheritance relationship by parent_tag name and priority
+  koji_tag_inheritance:
+    parent_tag: delete-3-parent
+    child_tag: delete-3-child
+    priority: 0
+    state: absent
+
+# Assert that we have no parents.
+
+- koji_call:
+    name: getInheritanceData
+    args: [delete-3-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data|length == 0

--- a/tests/integration/koji_tag_inheritance/delete-4.yml
+++ b/tests/integration/koji_tag_inheritance/delete-4.yml
@@ -1,0 +1,48 @@
+# Do *not* delete an inheritance relationship if the user specifies both
+# parent_tag and priority and one of those does not match an existing
+# relationship.
+---
+
+- koji_tag:
+    name: delete-4-parent
+    state: present
+
+- koji_tag:
+    name: delete-4-notparent
+    state: present
+
+- koji_tag:
+    name: delete-4-child
+    state: present
+    inheritance:
+    - parent: delete-4-parent
+      priority: 0
+
+- name: try to delete with the right parent_tag and wrong priority
+  koji_tag_inheritance:
+    parent_tag: delete-4-parent-b
+    child_tag: delete-4-child
+    priority: 100  # bzzt
+    state: absent
+  ignore_errors: yes
+
+- name: try to delete with the right priority and wrong parent_tag
+  koji_tag_inheritance:
+    parent_tag: delete-4-notparent  # bzzt
+    child_tag: delete-4-child
+    priority: 0
+    state: absent
+  ignore_errors: yes
+
+# Assert that we still have our parent.
+
+- koji_call:
+    name: getInheritanceData
+    args: [delete-4-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data|length == 1
+      - inheritance.data[0].name == 'delete-1-parent'
+      - inheritance.data[0].priority == 0

--- a/tests/integration/koji_tag_inheritance/main.yml
+++ b/tests/integration/koji_tag_inheritance/main.yml
@@ -4,4 +4,7 @@
   tasks:
   - include: create-1.yml
   - include: delete-1.yml
+  - include: delete-2.yml
+  - include: delete-3.yml
+  - include: delete-4.yml
   - include: update-1.yml


### PR DESCRIPTION
Prior to this change, we only tested deleting inheritance relationships by `parent_tag` name.

Add tests to cover deleting by `priority` as well. Now we have four scenarios:

1.   delete-1: Delete by `parent_tag` name only
2.   delete-2: Delete by `priority` only
3.   delete-3: Delete by `parent_tag` name and priority
4.   delete-4: Do *not* delete if `parent_tag` name and `priority` fail to match